### PR TITLE
Chat history

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -74,16 +74,22 @@ export function ChatPanel({
                 content: value,
                 role: 'user'
               })
-              id = id ?? Math.random().toString(36).slice(2) // random id up to 11 chars
-              await upsertChat({
-                chat_id: id,
-                title: 'TODO: make title: '+ id,
-                userId: userId || 'unknown-user-id', // TODO: try to get rid of unknown user id, higher up 
-                messages,
-                createdAt: new Date(),
-                path: "todo",
-                sharePath: "todo"
-              })
+              // FIXME: FYI this was breaking a couple of things with the chat history:
+              // - Overwriting the path and sharePath with invalid strings
+              // - Not setting `id`, but instead assigning a new id to `chat_id` which kept the items from appearing in the sidebar
+              // - For some reason doing this is also emptied the `messages` array which otherwise includes message objects
+              // All of this is being handled by the `append` function which is a helper we get from the next `ai` package
+              //
+              // id = id ?? Math.random().toString(36).slice(2) // random id up to 11 chars
+              // await upsertChat({
+              //   chat_id: id,
+              //   title: 'TODO: make title: '+ id,
+              //   userId: userId || 'unknown-user-id', // TODO: try to get rid of unknown user id, higher up
+              //   messages,
+              //   createdAt: new Date(),
+              //   path: "todo",
+              //   sharePath: "todo"
+              // })
             }}
             input={input}
             setInput={setInput}

--- a/components/sidebar-item.tsx
+++ b/components/sidebar-item.tsx
@@ -22,7 +22,8 @@ export function SidebarItem({ chat, children }: SidebarItemProps) {
   const pathname = usePathname()
   const isActive = pathname === chat.path
 
-  if (!chat?.chat_id) return null
+  // TODO: Remove this once we're clear on using `chat_id` or `id`
+  if (!chat?.chat_id && !chat?.id) return null
 
   return (
     <div className="relative">

--- a/components/sidebar-item.tsx
+++ b/components/sidebar-item.tsx
@@ -22,7 +22,7 @@ export function SidebarItem({ chat, children }: SidebarItemProps) {
   const pathname = usePathname()
   const isActive = pathname === chat.path
 
-  if (!chat?.id) return null
+  if (!chat?.chat_id) return null
 
   return (
     <div className="relative">

--- a/components/sidebar-list.tsx
+++ b/components/sidebar-list.tsx
@@ -8,6 +8,7 @@ export interface SidebarListProps {
 
 export async function SidebarList({ userId }: SidebarListProps) {
   const chats = await getChats(userId)
+  console.log('🔴 chats', chats)
 
   return (
     <div className="flex-1 overflow-auto">
@@ -16,7 +17,7 @@ export async function SidebarList({ userId }: SidebarListProps) {
           {chats.map(
             chat =>
               chat && (
-                <SidebarItem key={chat?.id} chat={chat}>
+                <SidebarItem key={chat.chat_id} chat={chat}>
                   <SidebarActions
                     chat={chat}
                     removeChat={removeChat}


### PR DESCRIPTION
I left a comment inline but with one of the recent changes to `chat-panel.tsx` we added a call to `upsertChat()` which was breaking a bunch of things with the way chat history works and not saving the actual messages in supabase. It was also breaking the URL and the Share URL. 

When we don't explicitly do the call, the `append` helper method from Next's `ai` package does all of this for us.

This solves it and temporarily allows for either `chat.chat_id` or `chat.id` as the unique identifier for a chat, but the default is `id` so we should probably stick with that unless there's a reason we'd intentionally wanted a `chat_id` field.